### PR TITLE
bugfix: Prevent draft posts to be displayed

### DIFF
--- a/web/app/features/Blog/BlogApi.ts
+++ b/web/app/features/Blog/BlogApi.ts
@@ -3,16 +3,18 @@ import { getClient } from '~/lib/sanity/getClient';
 import { BlogTypes } from '.';
 
 export function getPosts({ language }: { language: string }): Promise<BlogTypes.Post[]> {
-  const query = `*[_type=='post'  && language == '${
+  const query = `*[!(_id in path('drafts.**')) && _type=='post'  && language == '${
     language ?? defaultLanguage
   }' && type == 'post'] | order(_createdAt desc)`;
 
   return getClient().fetch(query);
 }
 
-export function getPost(slug?: string) {
-  const query = `*[_type == "post" && slug.current ==  $slug]`;
+export function getPost(slug?: string, preview = false) {
   const queryParams = { slug };
+  const query = preview
+    ? `*[_type == "post" && slug.current ==  $slug]`
+    : `*[!(_id in path('drafts.**')) && _type == "post" && slug.current ==  $slug]`;
 
   return getClient().fetch(query, queryParams);
 }

--- a/web/app/routes/$slug.tsx
+++ b/web/app/routes/$slug.tsx
@@ -32,14 +32,14 @@ export const loader: LoaderFunction = async ({
   request,
   params,
 }): Promise<LoaderData | Response> => {
-  let post = await BlogApi.getPost(params.slug);
+  const requestUrl = new URL(request?.url);
+  const preview = requestUrl?.searchParams?.get('preview') === process.env.SANITY_PREVIEW_SECRET;
+  let post = await BlogApi.getPost(params.slug, preview);
 
   if (!post || post.length === 0) {
     return redirect('/');
   }
 
-  const requestUrl = new URL(request?.url);
-  const preview = requestUrl?.searchParams?.get('preview') === process.env.SANITY_PREVIEW_SECRET;
   post = filterDataToSingleItem(post, preview);
   const [picture] = await UnsplashApi.getPictures({ quantity: 1 });
   const profile = (await auth.isAuthenticated(request))?.profile;

--- a/web/app/util/header/header.ts
+++ b/web/app/util/header/header.ts
@@ -2,7 +2,6 @@ import { truncate } from 'lodash';
 import { BlogTypes, ContentUtils } from '~/features/Blog';
 import tailwindcss from '~/styles/tailwind.css';
 import background from '~/styles/background.css';
-import { filterDataToSingleItem } from '~/lib/sanity/filterDataToSingleItem';
 import { domain, siteFullName } from '~/config';
 
 export function description(content: string): string {
@@ -60,18 +59,17 @@ export function globalLinks() {
 }
 
 export function postMeta(data: { post: BlogTypes.Post; preview: boolean }) {
-  const post = filterDataToSingleItem(data.post, data.preview);
-  const content = ContentUtils.blocksToText(post.content);
+  const content = ContentUtils.blocksToText(data.post.content);
   const desc = description(content.join(' '));
 
   return {
-    'title': `${siteFullName} - ${post.title}`,
+    'title': `${siteFullName} - ${data.post.title}`,
     'description': desc,
-    'og:title': `${siteFullName} - ${post.title}`,
+    'og:title': `${siteFullName} - ${data.post.title}`,
     'og:description': desc,
-    'og:url': `https://${domain}/${post.slug.current}`,
+    'og:url': `https://${domain}/${data.post.slug.current}`,
     'twitter:description': desc,
-    'og:image': `https://${domain}/img/${post.slug.current}.jpeg`,
-    'twitter:image': `https://${domain}/img/${post.slug.current}.jpeg`,
+    'og:image': `https://${domain}/img/${data.post.slug.current}.jpeg`,
+    'twitter:image': `https://${domain}/img/${data.post.slug.current}.jpeg`,
   };
 }


### PR DESCRIPTION
## Problem

Right before open sourcing this code base, we replaced our public Sanity dataset with a private one. This required us to authenticate every request to Sanity. It turns out that authenticated queries deliver everything, not only published content.

While creating a new blog post, we've noticed it got immediately published in the website, which is NOT the desired behavior.

## Solution

This PR resolves the issue, bringing back the ability to pass a query string parameter to see the post in preview mode.