### PR TITLE
fix: add https protocol to alternate links

### DIFF
--- a/web/app/util/header/header.ts
+++ b/web/app/util/header/header.ts
@@ -42,19 +42,19 @@ export function globalLinks() {
     {
       rel: 'alternate',
       type: 'application/rss+xml',
-      href: `${domain}/rss.xml`,
+      href: `https://${domain}/rss.xml`,
       title: `${siteFullName}'s XML Feed`,
     },
     {
       rel: 'alternate',
       type: 'application/atom+xml',
-      href: `${domain}/atom.xml`,
+      href: `https://${domain}/atom.xml`,
       title: `${siteFullName}'s Atom Feed`,
     },
     {
       rel: 'alternate',
       type: 'application/feed+json',
-      href: `${domain}/feed.json`,
+      href: `https://${domain}/feed.json`,
       title: `${siteFullName}'s JSON Feed`,
     },
   ];


### PR DESCRIPTION
These 3 links are currently broken due to the missing `https://` prefix to build the absolute path.

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/13774309/151990027-0871b917-f449-4b26-b68d-0c73f92ec59c.png)
![image](https://user-images.githubusercontent.com/13774309/151990132-29f09ec5-f917-4b3e-9466-3202401c2718.png)

</details>



